### PR TITLE
fix: ajuste no overflow do container principal

### DIFF
--- a/app.R
+++ b/app.R
@@ -370,19 +370,14 @@ body <- dashboardBody(
 
 ui <- dashboardPage(
   tags$head(
-    tags$style(HTML(".sidebar {
-                      height: 90vh; overflow-y: auto;}
-                    .tab-content > .active {
-                      height: 90vh; overflow: auto;}"
-    ) # close HTML       
-    )            # close tags$style
-  ),             # close tags#Head
-  
-  # 
-  # .container-fluid {
-  #   height: 90vh; overflow-y: auto;}
-  # 
-  
+    tags$style(
+      HTML(
+        "html, body {
+          overflow: scroll !important;  
+        }"
+       ) # close HTML       
+    )# close tags$style
+  ),# close tags#Head
   header = header,
   sidebar = sidebar,
   body = body


### PR DESCRIPTION
O que eu tinha passado antes não tinha funcionado pq no código original o `overflow: hidden` estava direto no HTML, aí foi necessário adicionar um `!important`  para sobrepor.

A outra solução mais permanente seria editar diretamente o HTML criado pelo template. Mas me pareceu trabalhoso demais procurar onde isso seria mudado, parece ser coisa que vem direto do pacote.

Mas acho que isso resolve bem! 

Ficou legal o dash, parabéns! 👍 